### PR TITLE
fix(recipe): Refactor recipe outputs to support result parsing

### DIFF
--- a/pollination/imageless_annual_glare/_raytracing.py
+++ b/pollination/imageless_annual_glare/_raytracing.py
@@ -57,7 +57,7 @@ class ImagelessAnnualGlare(DAG):
         description='Glare limit indicating presence of glare. This value is used when '
         'calculating glare autonomy (the fraction of hours in which the view is free '
         'of glare). The glare limit value is used to determine if the view is free of '
-        'glare. The glare limit must be in the range 0-1.', 
+        'glare. The glare limit must be in the range 0-1.',
         default=0.4,
         spec={'type': 'number', 'minimum': 0, 'maximum': 1},
     )
@@ -117,7 +117,7 @@ class ImagelessAnnualGlare(DAG):
         return [
             {
                 'from': DCGlareDGA()._outputs.view_rays_glare_autonomy,
-                'to': '../glare_autonomy/{{self.name}}.ga'
+                'to': '../ga/{{self.name}}.ga'
             }
         ]
 
@@ -137,6 +137,6 @@ class ImagelessAnnualGlare(DAG):
         return [
             {
                 'from': DCGlareDGP()._outputs.view_rays_dgp,
-                'to': '../daylight_glare_probability/{{self.name}}.dgp'
+                'to': '../dgp/{{self.name}}.dgp'
             }
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pollination-honeybee-radiance==0.21.1
-pollination-alias==0.9.13
-pollination-path==0.3.0
+pollination-honeybee-radiance==0.21.3
+pollination-alias==0.10.8
+pollination-path==0.3.1


### PR DESCRIPTION
This includes:

* Adding an alias for the glare autonomy results
* Ensuring that a sun-up-houts.txt is copied to the hourly DGP results
* Structuring the result folders so that the raw DGP values are separate from annual metrics like GA. This matches the structure of the annual-daylight recipe results and will make it straightforward if we want to add more annual metrics in the future.